### PR TITLE
Fix printing of dispersion gradient

### DIFF
--- a/psi4/src/psi4/scfgrad/scf_grad.cc
+++ b/psi4/src/psi4/scfgrad/scf_grad.cc
@@ -82,9 +82,11 @@ SCFDeriv::SCFDeriv(std::shared_ptr<scf::HF> ref_wfn, Options& options) :
     potential_ = ref_wfn->V_potential();
     if (ref_wfn->has_array_variable("-D Gradient")) {
         gradients_["-D Gradient"] = ref_wfn->array_variable("-D Gradient");
+        gradients_["-D Gradient"]->set_name("-D Gradient");
     }
     if (ref_wfn->has_array_variable("-D Hessian")) {
         hessians_["-D Hessian"] = ref_wfn->array_variable("-D Hessian");
+        hessians_["-D Hessian"]->set_name("-D Hessian");
     }
 
 }


### PR DESCRIPTION
## Description
Issue from forums: https://forum.psicode.org/t/dispersion-gradients/2979

## Dev notes & details
<!-- A bullet-point format description of what this PR does "at a glance."
     Target audience is code reviewers and other devs skimming PRs.
     Should be more technical than user notes. Should never be empty. -->
- [x] Fix issue where the dispersion correction contribution is not correctly labelled when debug printing is enabled. 

## Checklist
- [x] [All or relevant fraction of full tests run](http://psicode.org/psi4manual/master/build_planning.html#how-to-run-a-subset-of-tests)

## Status
- [x] Ready for review
- [x] Ready for merge
